### PR TITLE
Refactor pause playercontrol

### DIFF
--- a/Raposa/Assets/Scenes/Main.unity
+++ b/Raposa/Assets/Scenes/Main.unity
@@ -855,7 +855,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88f858e252d103d40af23bf40619e160, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pauseMenuUI: {fileID: 1638143943}
+  PauseMenuUI: {fileID: 1638143943}
 --- !u!1 &654127725
 GameObject:
   m_ObjectHideFlags: 0
@@ -981,8 +981,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 02f8554030696d245a8c0c001deea0d0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dist: 0.5
+  Dist: 0.2
   Player: {fileID: 1199603986}
+  DistanceObject: {x: 0, y: 0}
 --- !u!212 &709023021
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -1221,6 +1222,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Player: {fileID: 1199603986}
+  DistanceCamera: {x: 0, y: 0, z: 0}
 --- !u!1 &1072352923
 GameObject:
   m_ObjectHideFlags: 0
@@ -1549,6 +1551,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Speed: 0.7
+  Trigger: 0
 --- !u!50 &1199603988
 Rigidbody2D:
   serializedVersion: 4

--- a/Raposa/Assets/Scripts/CameraControl.cs
+++ b/Raposa/Assets/Scripts/CameraControl.cs
@@ -5,16 +5,16 @@ using UnityEngine;
 public class CameraControl : MonoBehaviour
 {
     public GameObject Player;
-    Vector3 distanceCamera;
+    public Vector3 DistanceCamera;
 
     private void Start()
     {
-        distanceCamera = transform.position - Player.transform.position;
+        DistanceCamera = transform.position - Player.transform.position;
     }
 
     // Update is called once per frame
     private void Update()
     {
-        transform.position = Player.transform.position + distanceCamera;
+        transform.position = Player.transform.position + DistanceCamera;
     }
 }

--- a/Raposa/Assets/Scripts/DestroyObject.cs
+++ b/Raposa/Assets/Scripts/DestroyObject.cs
@@ -4,23 +4,21 @@ using UnityEngine;
 
 public class DestroyObject : MonoBehaviour
 {
-    public float dist = 0.2f;    
-    public GameObject Player;    
-    Vector2 distanceObject; 
+    public float Dist = 0.2f;
+    public GameObject Player;
+    public Vector2 DistanceObject;
 
     // Update is called once per frame
-    void Update()    
+    void Update()
     {
-        if (!PauseMenu.GameIsPaused)
+        if (Player.GetComponent<PlayerControl>().Trigger)
         {
-            distanceObject = transform.position - Player.transform.position;
-            if (distanceObject.magnitude <= dist)
+            DistanceObject = transform.position - Player.transform.position;
+            if (DistanceObject.magnitude <= Dist)
             {
-                Debug.Log("Distance:" + distanceObject.magnitude);
-                if (Input.GetButtonDown("Fire1"))
-                {
-                    Destroy(gameObject);
-                }
+                Debug.Log("Distance:" + DistanceObject.magnitude);
+                
+                Destroy(gameObject);
             }
         }
     }

--- a/Raposa/Assets/Scripts/Map.cs
+++ b/Raposa/Assets/Scripts/Map.cs
@@ -29,6 +29,7 @@ public class Map : MonoBehaviour
     public void MapResume()
     {
         MapUI.SetActive(false);
+        FindObjectOfType<PlayerControl>().enabled = true;
         Time.timeScale = 1f;
         InMap = false;
         PauseMenu.GameIsPaused = false;
@@ -36,6 +37,7 @@ public class Map : MonoBehaviour
     public void SetMap()
     {
         MapUI.SetActive(true);
+        FindObjectOfType<PlayerControl>().enabled = false;
         Time.timeScale = 0f;
         InMap = true;
         PauseMenu.GameIsPaused = true;

--- a/Raposa/Assets/Scripts/PauseMenu.cs
+++ b/Raposa/Assets/Scripts/PauseMenu.cs
@@ -5,8 +5,7 @@ using UnityEngine;
 public class PauseMenu : MonoBehaviour
 {
     public static bool GameIsPaused = false;
-    public GameObject pauseMenuUI;
-
+    public GameObject PauseMenuUI;
 
     private void Update()
     {
@@ -29,14 +28,16 @@ public class PauseMenu : MonoBehaviour
     }           
     public void MenuResume()
     {
-        pauseMenuUI.SetActive(false);
+        PauseMenuUI.SetActive(false);
+        FindObjectOfType<PlayerControl>().enabled = true;
         Time.timeScale = 1f;
         GameIsPaused = false;
     }
 
     private void Pause()
     {
-        pauseMenuUI.SetActive(true);
+        PauseMenuUI.SetActive(true);
+        FindObjectOfType<PlayerControl>().enabled = false;
         Time.timeScale = 0f;
         GameIsPaused = true;
     }

--- a/Raposa/Assets/Scripts/PlayerControl.cs
+++ b/Raposa/Assets/Scripts/PlayerControl.cs
@@ -8,6 +8,7 @@ public class PlayerControl : MonoBehaviour
     private Rigidbody2D rb;
     private Vector2 direction;
     private Animator animator;
+    public bool Trigger = false;
 
     private void Start()
     {
@@ -17,23 +18,29 @@ public class PlayerControl : MonoBehaviour
 
     private void Update()
     {
-        if (!PauseMenu.GameIsPaused)
+        float xAxis = Input.GetAxisRaw("Horizontal");
+        float yAxis = Input.GetAxisRaw("Vertical");
+
+        direction = new Vector2(xAxis, yAxis);
+
+        animator.SetFloat("horizontal", direction.x);
+        animator.SetFloat("vertical", direction.y);
+        animator.SetFloat("speed", direction.sqrMagnitude);
+
+        if (direction != Vector2.zero)
         {
-            float xAxis = Input.GetAxisRaw("Horizontal");
-            float yAxis = Input.GetAxisRaw("Vertical");
+            animator.SetFloat("horizontalIdle", direction.x);
+            animator.SetFloat("verticalIdle", direction.y);
+        }
 
-            direction = new Vector2(xAxis, yAxis);
-
-            animator.SetFloat("horizontal", direction.x);
-            animator.SetFloat("vertical", direction.y);
-            animator.SetFloat("speed", direction.sqrMagnitude);
-
-            if (direction != Vector2.zero)
-            {
-                animator.SetFloat("horizontalIdle", direction.x);
-                animator.SetFloat("verticalIdle", direction.y);
-            }
-        } 
+        if (Input.GetButtonDown("Fire1"))
+        {
+            Trigger = true;
+        }
+        else
+        {
+            Trigger = false;
+        }
     }
 
     private void FixedUpdate()


### PR DESCRIPTION
Refactored PlayerControl and DestroyObject, moving the mouse clicks check statement. Created a new way of pausing the player interaction to be self-contained inside the PauseMenu Class. No conflicts were found.